### PR TITLE
Removed analytics confirmation overlay

### DIFF
--- a/src/app/layouts/PageLayout.tsx
+++ b/src/app/layouts/PageLayout.tsx
@@ -52,7 +52,7 @@ const PageLayout: FC<PageLayoutProps> = ({ children, ...toolbarProps }) => {
 
       <NoLambdaViewContractAlert />
       <ConfirmationOverlay />
-      <AnalyticsConfirmationOverlay />
+      {/* <AnalyticsConfirmationOverlay /> */}
     </>
   );
 };


### PR DESCRIPTION
The broken popup was the analytics collection confirmation modal. I just commented it out and now it goes straight to your wallet after create/restore flow.